### PR TITLE
Don't use u'' string literals

### DIFF
--- a/zxcvbn/matching.py
+++ b/zxcvbn/matching.py
@@ -95,13 +95,13 @@ def _calc_average_degree(graph):
 _load_frequency_lists()
 _load_adjacency_graphs()
 
-KEYBOARD_AVERAGE_DEGREE = _calc_average_degree(GRAPHS[u'qwerty'])
+KEYBOARD_AVERAGE_DEGREE = _calc_average_degree(GRAPHS['qwerty'])
 
 # slightly different for keypad/mac keypad, but close enough
-KEYPAD_AVERAGE_DEGREE = _calc_average_degree(GRAPHS[u'keypad'])
+KEYPAD_AVERAGE_DEGREE = _calc_average_degree(GRAPHS['keypad'])
 
-KEYBOARD_STARTING_POSITIONS = len(GRAPHS[u'qwerty'])
-KEYPAD_STARTING_POSITIONS = len(GRAPHS[u'keypad'])
+KEYBOARD_STARTING_POSITIONS = len(GRAPHS['qwerty'])
+KEYPAD_STARTING_POSITIONS = len(GRAPHS['keypad'])
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
I noticed that setup.py advertises Python 3.2 support, but matching.py uses `u''` string literals, which aren't supported on 3.2. This pull request turns those into `''` literals, which will fix Python 3.2 support. Note that since this file already imports `from __future__ import unicode_literals`, this
change will have no effect on Python 2.6 or 2.7 support.